### PR TITLE
Copy some code from initSession into restartSession

### DIFF
--- a/IdeSession/Update.hs
+++ b/IdeSession/Update.hs
@@ -278,9 +278,11 @@ restartSession IdeSession{ideStaticInfo, ideState} mInitParams = do
     restart idleState = do
       forceShutdownGhcServer $ _ideGhcServer idleState
       env    <- envWithPathOverride configExtraPathDirs
+      let ghcOpts = configStaticOpts
+                 ++ packageDbArgs (Version [7,4,2] []) configPackageDBStack
       server <-
         forkGhcServer
-          configGenerateModInfo configStaticOpts workingDir env configInProcess
+          configGenerateModInfo ghcOpts workingDir env configInProcess
       return . IdeSessionIdle
              . (ideComputed    ^= Maybe.nothing)
              . (ideUpdatedEnv  ^= True)


### PR DESCRIPTION
Without this change, restarted session do not know about the package databases we informed `initSession` of.

Pinging @snoyberg 
