### PR TITLE
Use System.IO.UTF8 to avoid character encoding issues (fpco/fpco#2232)

### DIFF
--- a/server/HsWalk.hs
+++ b/server/HsWalk.hs
@@ -27,10 +27,11 @@ import qualified Data.Text as Text
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BSSC
 import Data.Maybe (fromMaybe, fromJust)
-import Prelude hiding (id, mod, span)
+import Prelude hiding (id, mod, span, writeFile, appendFile)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
+import System.IO.UTF8 (writeFile, appendFile)
 
 import IdeSession.Types.Private
 import IdeSession.Strict.Container

--- a/server/ide-backend-server.cabal
+++ b/server/ide-backend-server.cabal
@@ -39,6 +39,7 @@ executable ide-backend-server
                       haddock              >= 2.11    && < 2.12,
                       attoparsec           >= 0.10    && < 0.11, 
                       binary               == 0.5.1.0,
+                      utf8-string,
                       template-haskell
 
   if impl(ghc >= 7.6.2)


### PR DESCRIPTION
This fixes a bug we saw in production (fpco/fpco#2232)
