### PR TITLE
Tweaks to getDotCabal

### DIFF
--- a/IdeSession/Query.hs
+++ b/IdeSession/Query.hs
@@ -42,6 +42,7 @@ import Prelude hiding (mod, span)
 import Data.Maybe (listToMaybe, maybeToList)
 import Data.List (isInfixOf)
 import Data.Accessor ((^.), (^:), getVal)
+import Data.Version (Version)
 import qualified System.FilePath.Find as Find
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Char8 as BSSC
@@ -306,7 +307,7 @@ getUseSites = computedQuery $ \computed@Computed{..} mod span ->
 -- or files with different names) are ignored so that they
 -- don't get in the way when we build an executable using the library
 -- and so that the behaviour is consistent with that of @buildExe@.
-getDotCabal :: Query (String -> BSL.ByteString)
+getDotCabal :: Query (String -> Version -> BSL.ByteString)
 getDotCabal session = withComputedState session
                       $ \idleState computed@Computed{..} -> do
   let sourcesDir = ideSourcesDir $ ideStaticInfo session


### PR DESCRIPTION
1. Allow a caller to set the package's version.
2. Ensure that hs-source-dirs is not set when using getDotCabal.
