### PR TITLE
Use binary-ide-backend

### DIFF
--- a/ide-backend.cabal
+++ b/ide-backend.cabal
@@ -71,7 +71,7 @@ library
                       unordered-containers >= 0.2.3   && < 0.3,
                       text                 >= 0.11    && < 0.12,
                       fingertree           >= 0.0.1   && < 0.2,
-                      binary               >= 0.7.1.0 && < 0.8,
+                      binary-ide-backend   >= 0.7.1.0 && < 0.8,
                       data-accessor        >= 0.2     && < 0.3,
                       data-accessor-mtl    >= 0.2     && < 0.3,
                       crypto-api           >= 0.12    && < 0.13,
@@ -170,7 +170,7 @@ test-suite rpc-server
                       HUnit                >= 1.2     && < 1.3,
                       executable-path      >= 0.0     && < 0.1,
                       unix                 >= 2.5     && < 2.8,
-                      binary               >= 0.7.1.0 && < 0.8,
+                      binary-ide-backend   >= 0.7.1.0 && < 0.8,
                       template-haskell
 
   default-language:   Haskell2010


### PR DESCRIPTION
This change simplifies our build process. Is there any downside to using binary-ide-backend in both ide-backend and ide-backend-server?
