### PR TITLE
Allow clients to configure the location of ide-backend-{server/exe-cabal}

### DIFF
--- a/ide-backend/IdeSession/Config.hs
+++ b/ide-backend/IdeSession/Config.hs
@@ -6,6 +6,7 @@ module IdeSession.Config (
 
 import Distribution.License (License (..))
 import Distribution.Simple (PackageDB (..), PackageDBStack)
+import Distribution.Simple.Program.Find (ProgramSearchPath,defaultProgramSearchPath)
 
 type InProcess = Bool
 
@@ -53,6 +54,14 @@ data SessionConfig = SessionConfig {
     -- | Delete temporary files when session finishes?
     -- (Defaults to True; mostly for internal debugging purposes)
   , configDeleteTempFiles :: Bool
+    -- | The name of the ide-backend-server program to use, and where to find it.
+    --   The default is @(defaultProgramSearchPath,"ide-backend-server")@,
+    --   that is, to look for a program called ide-backend-server on the system
+    --   search path only.
+  , configIdeBackendServer :: (ProgramSearchPath,FilePath)
+    -- | The name of the ide-backend-exe-cabal program to use, and where to find it.
+    --   The default is @(defaultProgramSearchPath,"ide-backend-exe-cabal")@.
+  , configIdeBackendExeCabal :: (ProgramSearchPath,FilePath)
   }
 
 -- | Default session configuration
@@ -78,6 +87,8 @@ data SessionConfig = SessionConfig {
 -- >       ]
 -- >   , configLog              = const $ return ()
 -- >   , configDeleteTempFiles  = True
+-- >   , configIdeBackendServer = (defaultProgramSearchPath,"ide-backend-server")
+-- >   , configIdeBackendExeCabal = (defaultProgramSearchPath,"ide-backend-exe-cabal")
 -- >   }
 defaultSessionConfig :: SessionConfig
 defaultSessionConfig = SessionConfig {
@@ -98,4 +109,6 @@ defaultSessionConfig = SessionConfig {
       ]
   , configLog              = const $ return ()
   , configDeleteTempFiles  = True
+  , configIdeBackendServer = (defaultProgramSearchPath,"ide-backend-server")
+  , configIdeBackendExeCabal = (defaultProgramSearchPath,"ide-backend-exe-cabal")
   }

--- a/ide-backend/IdeSession/ExeCabalClient.hs
+++ b/ide-backend/IdeSession/ExeCabalClient.hs
@@ -27,7 +27,7 @@ import IdeSession.Util
 invokeExeCabal :: IdeStaticInfo -> ExeCabalRequest -> (Progress -> IO ())
                -> IO ExitCode
 invokeExeCabal ideStaticInfo@IdeStaticInfo{..} args callback = do
-  mLoc <- findProgramOnSearchPath normal searchPath "ide-backend-exe-cabal"
+  mLoc <- findProgramOnSearchPath normal searchPath ide_backend_exe_cabal
   case mLoc of
     Nothing ->
       fail $ "Could not find ide-backend-exe-cabal"
@@ -41,9 +41,7 @@ invokeExeCabal ideStaticInfo@IdeStaticInfo{..} args callback = do
       shutdown server  -- not long-running
       return exitCode
   where
-    searchPath :: ProgramSearchPath
-    searchPath = ProgramSearchPathDefault
-               : map ProgramSearchPathDir configExtraPathDirs
+    (searchPath,ide_backend_exe_cabal) = configIdeBackendExeCabal
 
     SessionConfig{..} = ideConfig
 

--- a/ide-backend/IdeSession/GHC/Client.hs
+++ b/ide-backend/IdeSession/GHC/Client.hs
@@ -71,7 +71,7 @@ forkGhcServer :: [String]      -- ^ Initial ghc options
 forkGhcServer ghcOpts relIncls rtsOpts ideStaticInfo = do
   when configInProcess $
     fail "In-process ghc server not currently supported"
-  mLoc <- findProgramOnSearchPath normal searchPath "ide-backend-server"
+  mLoc <- findProgramOnSearchPath normal searchPath ide_backend_server
   case mLoc of
     Nothing ->
       fail $ "Could not find ide-backend-server"
@@ -103,9 +103,7 @@ forkGhcServer ghcOpts relIncls rtsOpts ideStaticInfo = do
          : ghcOpts
         ++ relInclToOpts (ideSourceDir ideStaticInfo) relIncls
 
-    searchPath :: ProgramSearchPath
-    searchPath = map ProgramSearchPathDir configExtraPathDirs
-              ++ [ProgramSearchPathDefault]
+    (searchPath, ide_backend_server) = configIdeBackendServer
 
     SessionConfig{..} = ideConfig ideStaticInfo
 


### PR DESCRIPTION
The idea is to allow clients to indicate how to find the programs `ide-backend-server` and `ide-backend-exe-cabal` via new fields in `SessionConfig`. The `defaultSessionConfig` mimics the old behaviour: to look for programs named `"ide-backend-server"` / `"ide-backend-exe-cabal"` on the system path, with the caveat that any client that previously relied on setting an appropriate path in `configExtraPathDirs` will have to be updated.

The main motivation is to allow clients to easily pick the instance of ide-backend-server that corresponds to the version of ghc in use in the current project (in a setting with more than one version of ghc in use, etc).