### PR TITLE
Don't force a dependency on Cabal-ide-backend

### DIFF
--- a/ide-backend/IdeSession.hs
+++ b/ide-backend/IdeSession.hs
@@ -104,6 +104,8 @@ module IdeSession (
     SessionConfig(..)
   , defaultSessionConfig
   , InProcess
+  , ProgramSearchPath
+  , ProgramSearchPathEntry(..)
     -- * Updating the session
     -- ** Starting and stopping
   , IdeSession -- Abstract

--- a/ide-backend/IdeSession/Config.hs
+++ b/ide-backend/IdeSession/Config.hs
@@ -1,12 +1,13 @@
 module IdeSession.Config (
     SessionConfig(..)
   , InProcess
+  , ProgramSearchPath, ProgramSearchPathEntry(..)
   , defaultSessionConfig
   ) where
 
 import Distribution.License (License (..))
 import Distribution.Simple (PackageDB (..), PackageDBStack)
-import Distribution.Simple.Program.Find (ProgramSearchPath,defaultProgramSearchPath)
+import Distribution.Simple.Program.Find (ProgramSearchPath,ProgramSearchPathEntry(..),defaultProgramSearchPath)
 
 type InProcess = Bool
 


### PR DESCRIPTION
Because #291 added to `SessionConfig` fields with a `ProgramSearchPath`, which is currently defined in`Cabal-ide-backend`, clients will most likely have to depend on that package in order to build or manipulate a `SessionConfig`, which is unfortunate. This is easily fixed by re-exporting `ProgramSearchPath` and `ProgramSearchPathEntry`.