### PR TITLE
Fixing the search for the GHC executable on WIndows

### DIFF
--- a/ide-backend-common/IdeSession/Util/PortableFiles.hs
+++ b/ide-backend-common/IdeSession/Util/PortableFiles.hs
@@ -3,6 +3,7 @@ module IdeSession.Util.PortableFiles (
     setFileTimes
   , getFileStatus
   , modificationTime
+  , toExecutable
   , moduleNameToExeName
 ) where
 
@@ -25,11 +26,16 @@ setFileTimes :: FilePath -> EpochTime -> EpochTime -> IO ()
 -- Converts a module name to and executable file name
 moduleNameToExeName :: String -> String
 
+-- Converts a name of an a executable to the corresponding file name
+toExecutable :: String -> String
+
 #ifdef VERSION_unix
 
 setFileTimes = Posix.setFileTimes
 
 moduleNameToExeName = id
+
+toExecutable = id
 
 #else
 
@@ -59,5 +65,7 @@ setFileTimes path atime mtime =
                  .|. Win32.fILE_FLAG_BACKUP_SEMANTICS -- required for directories
 
 
-moduleNameToExeName m = m ++ ".exe"
+moduleNameToExeName = toExecutable
+
+toExecutable e = e ++ ".exe"
 #endif

--- a/ide-backend-server/Run.hs
+++ b/ide-backend-server/Run.hs
@@ -107,6 +107,7 @@ import IdeSession.Types.Public (RunBufferMode(..), Targets(..))
 import IdeSession.Types.Private
 import qualified IdeSession.Types.Public as Public
 import IdeSession.Util
+import IdeSession.Util.PortableFiles (toExecutable)
 import IdeSession.Strict.Container
 import IdeSession.Strict.IORef
 import qualified IdeSession.Strict.List as StrictList
@@ -134,7 +135,7 @@ optsToDynFlags = map noLoc
 
 getGhcLibdir :: IO FilePath
 getGhcLibdir = do
-  let ghcbinary = "ghc-" ++ GHC.cProjectVersion
+  let ghcbinary = toExecutable $ "ghc-" ++ GHC.cProjectVersion
   out <- readProcess ghcbinary ["--print-libdir"] ""
   case lines out of
     [libdir] -> return libdir

--- a/ide-backend/test/rpc-server.hs
+++ b/ide-backend/test/rpc-server.hs
@@ -14,7 +14,7 @@ import System.Environment (getArgs)
 import System.Environment.Executable (getExecutablePath)
 import System.FilePath ((</>))
 import System.IO (hClose)
-import System.IO.Temp (withTempDirectory, openTempFile)
+import System.IO.Temp (openTempFile)
 -- import System.Posix.Signals (sigKILL)
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception        as Ex


### PR DESCRIPTION
This fixes a bug when searching for the GHC executable on Windows. Currently the search throws an exception and everything hangs. The fix amounts to appending the `.exe` suffix to the name being searched for.
